### PR TITLE
Bug fix to GATKDoclet to ensure default values are always emitted whe…

### DIFF
--- a/public/gatk-utils/src/main/java/org/broadinstitute/gatk/utils/help/GenericDocumentationHandler.java
+++ b/public/gatk-utils/src/main/java/org/broadinstitute/gatk/utils/help/GenericDocumentationHandler.java
@@ -190,7 +190,6 @@ public abstract class GenericDocumentationHandler extends DocumentedGATKFeatureH
                         argBindings.put("maxValue", "NA");
                         argBindings.put("minRecValue", "NA");
                         argBindings.put("maxRecValue", "NA");
-                        argBindings.put("defaultValue", "NA");
                     }
                     // Finalize argument bindings
                     args.get(kind).add(argBindings);


### PR DESCRIPTION
…n they are present instead of emitting NA in some cases.
